### PR TITLE
Proposal for a wordlist implementation

### DIFF
--- a/lingpy3/basic/__init__.py
+++ b/lingpy3/basic/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/basic/wordlist.py
+++ b/lingpy3/basic/wordlist.py
@@ -1,0 +1,204 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+from itertools import groupby
+
+from six import text_type
+from clldutils.misc import cached_property
+
+from lingpy3.util import uniq
+
+
+def split(value):
+    return value.split()
+
+
+def join(values):
+    return ' '.join(values)
+
+
+class Wordlist(object):
+    def __init__(self, header, rows, id_='id', concept='concept', language='doculect'):
+        """
+        Initialize a Wordlist object.
+
+        :param header: `list` of column headers.
+        :param rows: `list` of `list`s, constituting the body of the wordlist.
+        :param id_: Name of the column to regard as ID.
+        :param concept: Name of the column storing the concept ID.
+        :param language: Name of the column storing the language ID.
+        """
+        # For performance reasons we store a wordlist as list of lists, rather than as
+        # list of OrderedDicts. To allow dict-like access, we have to compute (and
+        # possibly update) indexes to map row IDs to list indices and column names to
+        # list indices.
+
+        if len(set(header)) != len(header):
+            raise ValueError('column names must be unique')
+        if not all(isinstance(col, text_type) for col in header):
+            raise ValueError('column names must be unicode')
+        if not all(col in header for col in [id_, language, concept]):
+            raise ValueError('id_, concept and language columns must be present')
+        self._rows = []
+        for row in rows:
+            if not (isinstance(row, (tuple, list)) and len(row) == len(header)):
+                raise ValueError('rows must be lists of same length as the header')
+            self._rows.append(tuple(row))
+        self.header = tuple(header)
+        self.concept_col = concept
+        self.language_col = language
+        self.id_col = id_
+
+        # Map header names to list index in self.header:
+        self._header2index = {h: i for i, h in enumerate(self.header)}
+
+        # Map row IDs to list index in self._rows:
+        id_index = self._header2index.get(id_, 0)
+        self._id2index = {row[id_index]: i for i, row in enumerate(self._rows)}
+
+        # Make sure row IDs are unique:
+        if len(self._id2index) != len(self._rows):
+            raise ValueError('duplicate row IDs in wordlist')
+
+    def _row_index(self, row):
+        """
+        :param row: int or text_type, specifying 1-based row index or row ID.
+        :return: list index
+        """
+        return row - 1 if isinstance(row, int) else self._id2index[row]
+
+    def _col_index(self, col):
+        """
+        :param col: int or text_type, specifying 1-based column index or column name.
+        :return: list index
+        """
+        _map = {'concept': self.concept_col, 'language': self.language_col}
+        return col - 1 if isinstance(col, int) else self._header2index[_map.get(col, col)]
+
+    def __iter__(self):
+        """
+        Iterating over a wordlist means iterating over its rows.
+        """
+        return iter(self._rows)
+
+    @cached_property()
+    def languages(self):
+        """
+        :return: `list` of unique language identifiers used in the wordlist.
+        """
+        return self.get_distinct(self.language_col)
+
+    @cached_property()
+    def concepts(self):
+        """
+        :return: `list` of unique concept identifiers used in the wordlist.
+        """
+        return self.get_distinct(self.concept_col)
+
+    def __getitem__(self, item):
+        if isinstance(item, tuple):
+            assert len(item) == 2
+            return self._rows[self._row_index(item[0])][self._col_index(item[1])]
+        return self._rows[self._row_index(item)]
+
+    def iter_slices(self, cols, rows=None):
+        """
+        Iterate over rows or the whole wordlist, yielding slices of each row.
+
+        :param cols: `list` of columns to include in each slice.
+        :param rows: Iterable of rows
+        :return: Generator object.
+        """
+        if not isinstance(cols, (list, tuple)):
+            cols = [cols]
+        rows = rows or self
+        cols = [self._col_index(col) for col in cols]
+        if len(cols) == 0:
+            return rows
+        if len(cols) == 1:
+            return (r[cols[0]] for r in rows)
+        return ([r[col] for col in cols] for r in rows)
+
+    def get_slices(self, cols, rows=None):
+        """
+        Slice values specified by `cols` out of rows.
+
+        :param cols:
+        :param rows:
+        :return: `list` of slices
+        """
+        return list(self.iter_slices(cols, rows=rows))
+
+    def filter(self, **query):
+        """
+        Filter wordlist rows based on criteria for values.
+
+        :param query: Filter criteria keyed by column name.
+        :return: generator object.
+        """
+        query = [(self._col_index(col), q) for col, q in query.items()]
+        return (row for row in self if all(row[col] == q for col, q in query))
+
+    def get_distinct(self, *cols):
+        """
+        :param cols: slice specification.
+        :return: `list` of distinct slices.
+        """
+        return uniq(self.iter_slices(cols))
+
+    def iter_grouped(self, key, *cols, **query):
+        """
+        Iterate over lists of slices grouped by value for the column specified as `key`.
+
+        :param key:
+        :param cols: slice specification.
+        :param query: filter specification.
+        :return: Generator of (key, slices) pairs.
+        """
+        if not isinstance(key, int):
+            key = self._header2index[key]
+        for k, rows in groupby(
+                sorted(self.filter(**query) if query else self, key=lambda r: r[key]),
+                lambda r: r[key]):
+            yield k, list(self.iter_slices(cols, rows=rows))
+
+    def iter_by_language(self, *cols, **query):
+        return self.iter_grouped(self.language_col, *cols, **query)
+
+    def get_by_language(self, *cols, **query):
+        return list(self.iter_by_language(*cols, **query))
+
+    def get_dict_by_language(self, *cols, **query):
+        return {k: items for k, items in self.iter_by_language(*cols, **query)}
+
+    def iter_by_concept(self, *cols, **query):
+        return self.iter_grouped(self.concept_col, *cols, **query)
+
+    def get_by_concept(self, *cols, **query):
+        return list(self.iter_by_concept(*cols, **query))
+
+    def get_dict_by_concept(self, *cols, **query):
+        return {k: items for k, items in self.iter_by_concept(*cols, **query)}
+
+    def add_col(self, col, func, override=False, **kw):
+        """
+        Add a column to all rows in the wordlist.
+
+        :param col: The name of the new column.
+        :param func: A callable accepting a row represented as dict, returning the \
+        value for the new column for the row.
+        """
+        assert isinstance(col, text_type)
+        if col in [self.id_col, self.concept_col, self.language_col]:
+            raise ValueError('cannot overwrite values of reserved columns')
+        if col in self.header:
+            if not override:
+                raise ValueError('to overwrite existing columns, specify `override=True`')
+            index = self.header.index(col)
+        else:
+            index = len(self.header)
+            self.header = tuple(list(self.header) + [col])
+        self._header2index = {h: i for i, h in enumerate(self.header)}
+        for i, row in enumerate(self):
+            row = list(self._rows[i])
+            row.insert(index, func(dict(zip(self.header, row)), **kw))
+            self._rows[i] = tuple(row)

--- a/lingpy3/basic/wordlist.py
+++ b/lingpy3/basic/wordlist.py
@@ -74,6 +74,9 @@ class Wordlist(object):
         _map = {'concept': self.concept_col, 'language': self.language_col}
         return col - 1 if isinstance(col, int) else self._header2index[_map.get(col, col)]
 
+    def __len__(self):
+        return len(self._rows)
+
     def __iter__(self):
         """
         Iterating over a wordlist means iterating over its rows.
@@ -103,6 +106,14 @@ class Wordlist(object):
             assert len(item) == 2
             return self._rows[self._row_index(item[0])][self._col_index(item[1])]
         return self._rows[self._row_index(item)]
+
+    def __setitem__(self, item, value):
+        """
+        Modify a specific cell in a specific column of a wordlist.
+        """
+        if not (isinstance(item, tuple) and len(item) == 2):
+            raise ValueError('invalid wordlist __setitem__ index')
+        self._rows[self._row_index(item[0])][self._col_index(item[1])] = value
 
     def iter_slices(self, cols, rows=None):
         """
@@ -182,6 +193,15 @@ class Wordlist(object):
 
     def get_dict_by_concept(self, *cols, **query):
         return {k: items for k, items in self.iter_by_concept(*cols, **query)}
+
+    def get_etymdict(self, ref='cogid'):
+        res = {}
+        lmap = {l: i for i, l in enumerate(self.languages)}
+        for cogid, rows in self.iter_grouped(ref, self.id_col, self.language_col):
+            res[cogid] = [[] for _ in self.languages]
+            for id_, lang in rows:
+                res[cogid][lmap[lang]].append(id_)
+        return res
 
     def add_col(self, col, func, override=False, **kw):
         """

--- a/lingpy3/tests/basic/__init__.py
+++ b/lingpy3/tests/basic/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/tests/basic/test_wordlist.py
+++ b/lingpy3/tests/basic/test_wordlist.py
@@ -1,0 +1,36 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+from unittest import TestCase
+
+
+class Tests(TestCase):
+    def _make_one(self, header=None, rows=None, **kw):
+        from lingpy3.basic.wordlist import Wordlist
+
+        return Wordlist(
+            ['id', 'concept', 'doculect'] if header is None else header,
+            [['1', 'c1', 'l1']] if rows is None else rows,
+            **kw)
+
+    def test_init(self):
+        self._make_one()
+
+        # invalid data type for header:
+        with self.assertRaises(ValueError):
+            self._make_one(header=['id', 'concept', 'doculect', 5])
+
+        # duplicate column names in header:
+        with self.assertRaises(ValueError):
+            self._make_one(header=['id', 'concept', 'doculect', 'id'])
+
+        # missing columns in header:
+        with self.assertRaises(ValueError):
+            self._make_one(header=[])
+
+        # row length not matching header length:
+        with self.assertRaises(ValueError):
+            self._make_one(rows=[[1, 2]])
+
+        # duplicate row ID:
+        with self.assertRaises(ValueError):
+            self._make_one(rows=[[1, 2, 3], [1, 2, 3]])

--- a/lingpy3/tests/basic/test_wordlist.py
+++ b/lingpy3/tests/basic/test_wordlist.py
@@ -35,6 +35,10 @@ class Tests(TestCase):
         with self.assertRaises(ValueError):
             self._make_one(rows=[[1, 2, 3], [1, 2, 3]])
 
+    def test_get_etymdict(self):
+        wl = self._make_one()
+        self.assertEqual(wl.get_etymdict(ref='concept'), {'c1': [['1']]})
+
     def test_add_col(self):
         wl = self._make_one()
 
@@ -53,3 +57,5 @@ class Tests(TestCase):
 
         wl.add_col('zcol', lambda x: x['xcol'])
         self.assertEqual(wl['1', 'zcol'], 'y')
+        wl['1', 'xcol'] = 'z'
+        self.assertEqual(wl['1', 'xcol'], 'z')

--- a/lingpy3/tests/basic/test_wordlist.py
+++ b/lingpy3/tests/basic/test_wordlist.py
@@ -7,10 +7,23 @@ class Tests(TestCase):
     def _make_one(self, header=None, rows=None, **kw):
         from lingpy3.basic.wordlist import Wordlist
 
+        _header = ['id', 'doculect', 'concept', 'ipa', 'cognates', 'x']
+        _rows = [
+            ['1', 'l1', 'hand, arm', 'aber', 'a', 'abera'],
+            ['2', 'l2', 'hand, arm', 'aber', 'b', 'aberb'],
+            ['3', 'l3', 'hand, arm', 'aba', 'a', 'abaa'],
+            ['4', 'l4', 'hand, arm', 'abra kadabra', 'b', 'abra kadabrab'],
+            ['5', 'l5', 'hand, arm', 'test\u201dtest', 'a', 'test\u201dtesta'],
+            ['6', 'l1', 'foot', 'was', 'a', 'wasa'],
+            ['7', 'l2', 'foot', 'den', 'fb', 'denfb'],
+            ['8', 'l3', 'foot', 'hier', 'fa', 'hierfa'],
+            ['9', 'l4', 'foot', 'fu\xdf', 'fb', 'fu\xdffb'],
+            ['10', 'l5', 'foot', 'haut', 'fa', 'hautfa'],
+            ['11', 'l1', 'knee', 'Knie', 'gc', 'Kniegc'],
+        ]
+
         return Wordlist(
-            ['id', 'concept', 'doculect'] if header is None else header,
-            [['1', 'c1', 'l1']] if rows is None else rows,
-            **kw)
+            _header if header is None else header, _rows if rows is None else rows, **kw)
 
     def test_init(self):
         self._make_one()
@@ -37,7 +50,24 @@ class Tests(TestCase):
 
     def test_get_etymdict(self):
         wl = self._make_one()
-        self.assertEqual(wl.get_etymdict(ref='concept'), {'c1': [['1']]})
+        self.assertEqual(
+            wl.get_etymdict(ref='concept'),
+            {
+                'foot': [['6'], ['7'], ['8'], ['9'], ['10']],
+                'hand, arm': [['1'], ['2'], ['3'], ['4'], ['5']],
+                'knee': [['11'], [], [], [], []]})
+
+    def test_iter_paps(self):
+        wl = self._make_one()
+        self.assertEqual(
+            list(wl.iter_paps(ref='cognates', missing=-1)),
+            [
+                ('a', [1, 1, 1, 1, 1]),
+                ('b', [0, 1, 0, 1, 0]),
+                ('fa', [0, 0, 1, 0, 1]),
+                ('fb', [0, 1, 0, 1, 0]),
+                ('gc', [1, -1, -1, -1, -1])
+            ])
 
     def test_add_col(self):
         wl = self._make_one()

--- a/lingpy3/tests/basic/test_wordlist.py
+++ b/lingpy3/tests/basic/test_wordlist.py
@@ -34,3 +34,22 @@ class Tests(TestCase):
         # duplicate row ID:
         with self.assertRaises(ValueError):
             self._make_one(rows=[[1, 2, 3], [1, 2, 3]])
+
+    def test_add_col(self):
+        wl = self._make_one()
+
+        with self.assertRaises(ValueError):
+            wl.add_col('id', lambda x: 'x')
+
+        wl.add_col('xcol', lambda x: 'x')
+        self.assertEqual(wl['1', 'xcol'], 'x')
+        self.assertEqual(wl.header[-1], 'xcol')
+
+        with self.assertRaises(ValueError):
+            wl.add_col('xcol', lambda x: 'x')
+
+        wl.add_col('xcol', lambda x: 'y', override=True)
+        self.assertEqual(wl['1', 'xcol'], 'y')
+
+        wl.add_col('zcol', lambda x: x['xcol'])
+        self.assertEqual(wl['1', 'zcol'], 'y')


### PR DESCRIPTION
The propsed implementation is somewhat close to the current one in that
it stores the data as list of lists. The API to access data has been
changed considerably, though. While sometimes more verbose, I think it
is also more powerful.

Below is a translation of the old API to the new one.

- LingPy 2.5:
```python
from lingpy import Wordlist

wl = Wordlist('test.tsv')
print wl[1]
print wl[1, 'concept']
print wl.ipa
print wl.language
print wl.concept
print wl.get_dict(col="l1",entry="ipa")
print wl.get_list(row="foot",entry="cognates",flat=True)
```

- LingPy3:
```python
from clldutils.dsv import reader
from lingpy3.basic.wordlist import Wordlist

rows = list(reader('../lingpy/test.tsv', delimiter='\t'))
wl = Wordlist(rows[0], rows[1:])
print wl[1]
print wl[1, 'concept']
print [rows for _, rows in wl.get_by_concept('ipa')]
print wl.languages
print wl.concepts
print wl.get_dict_by_concept('ipa', language='l1')
print wl.get_slices('cognates', rows=wl.filter(concept='foot'))
```

The API to add columns has been changed, too. The callable passed into
`add_col` receives the data of a row as `dict` and must return the
value for the new column:
```python
wl.add_col('x', lambda i: i['ipa'] + i['cognates'])
print wl.get_slices('x')
```