### PR TITLE
fleshed out design for io handling

### DIFF
--- a/lingpy3/__init__.py
+++ b/lingpy3/__init__.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals, print_function, division
 from lingpy3 import registry
 from lingpy3.sequence.soundclassmodel import SoundClassModel, DiacriticsVowelsTones
 from lingpy3 import settings
+from lingpy3 import interfaces
+from lingpy3 import io
 
 __version__ = "1.0"
 PROG = 'LingPy3-{0}'.format(__version__)

--- a/lingpy3/algorithm/cython/_calign.py
+++ b/lingpy3/algorithm/cython/_calign.py
@@ -165,7 +165,7 @@ def globalign(
             almB += [seqB[i-1]]
             i -= 1
             j -= 1
-        else:
+        else:  # pragma: no cover
             almA += [seqA[j-1]]
             almB += ['-']
             j -= 1
@@ -353,7 +353,7 @@ def secondary_globalign(
             almB += [seqB[i-1]]
             i -= 1
             j -= 1
-        else:
+        else:  # pragma: no cover
             almA += [seqA[j-1]]
             almB += ['-']
             j -= 1

--- a/lingpy3/algorithm/cython/calign.c
+++ b/lingpy3/algorithm/cython/calign.c
@@ -2421,7 +2421,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_globalign(CYTHON_U
  *             almB += [seqB[i-1]]
  *             i -= 1             # <<<<<<<<<<<<<<
  *             j -= 1
- *         else:
+ *         else:  # pragma: no cover
  */
       __pyx_v_i = (__pyx_v_i - 1);
 
@@ -2429,7 +2429,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_globalign(CYTHON_U
  *             almB += [seqB[i-1]]
  *             i -= 1
  *             j -= 1             # <<<<<<<<<<<<<<
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]
  */
       __pyx_v_j = (__pyx_v_j - 1);
@@ -2446,7 +2446,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_globalign(CYTHON_U
 
     /* "lingpy3/algorithm/cython/calign.pyx":168
  *             j -= 1
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]             # <<<<<<<<<<<<<<
  *             almB += ['-']
  *             j -= 1
@@ -2471,7 +2471,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_globalign(CYTHON_U
       __pyx_t_7 = 0;
 
       /* "lingpy3/algorithm/cython/calign.pyx":169
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]
  *             almB += ['-']             # <<<<<<<<<<<<<<
  *             j -= 1
@@ -3949,7 +3949,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_2secondary_globali
  *             almB += [seqB[i-1]]
  *             i -= 1             # <<<<<<<<<<<<<<
  *             j -= 1
- *         else:
+ *         else:  # pragma: no cover
  */
       __pyx_v_i = (__pyx_v_i - 1);
 
@@ -3957,7 +3957,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_2secondary_globali
  *             almB += [seqB[i-1]]
  *             i -= 1
  *             j -= 1             # <<<<<<<<<<<<<<
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]
  */
       __pyx_v_j = (__pyx_v_j - 1);
@@ -3974,7 +3974,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_2secondary_globali
 
     /* "lingpy3/algorithm/cython/calign.pyx":356
  *             j -= 1
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]             # <<<<<<<<<<<<<<
  *             almB += ['-']
  *             j -= 1
@@ -3999,7 +3999,7 @@ static PyObject *__pyx_pf_7lingpy3_9algorithm_6cython_6calign_2secondary_globali
       __pyx_t_7 = 0;
 
       /* "lingpy3/algorithm/cython/calign.pyx":357
- *         else:
+ *         else:  # pragma: no cover
  *             almA += [seqA[j-1]]
  *             almB += ['-']             # <<<<<<<<<<<<<<
  *             j -= 1

--- a/lingpy3/algorithm/cython/calign.pyx
+++ b/lingpy3/algorithm/cython/calign.pyx
@@ -164,7 +164,7 @@ def globalign(
             almB += [seqB[i-1]]
             i -= 1
             j -= 1
-        else:
+        else:  # pragma: no cover
             almA += [seqA[j-1]]
             almB += ['-']
             j -= 1
@@ -352,7 +352,7 @@ def secondary_globalign(
             almB += [seqB[i-1]]
             i -= 1
             j -= 1
-        else:
+        else:  # pragma: no cover
             almA += [seqA[j-1]]
             almB += ['-']
             j -= 1

--- a/lingpy3/basic/wordlist.py
+++ b/lingpy3/basic/wordlist.py
@@ -3,10 +3,12 @@ from __future__ import unicode_literals, print_function, division
 from itertools import groupby, chain
 from operator import itemgetter
 
+from zope.interface import implementer
 from six import text_type
 from clldutils.misc import cached_property
 
 from lingpy3.util import uniq
+from lingpy3.interfaces import IWordlist
 
 
 def split(value):
@@ -17,6 +19,7 @@ def join(values):
     return ' '.join(values)
 
 
+@implementer(IWordlist)
 class Wordlist(object):
     def __init__(self, header, rows, id_='id', concept='concept', language='doculect'):
         """

--- a/lingpy3/interfaces.py
+++ b/lingpy3/interfaces.py
@@ -3,6 +3,41 @@ from __future__ import unicode_literals, print_function, division
 from zope.interface import Interface, Attribute
 
 
+class IPath(Interface):
+    """"""
+
+
+class IText(Interface):
+    """"""
+
+
+class IWordlist(Interface):
+    """
+
+    """
+    concept_col = Attribute("""""")
+    language_col = Attribute("""""")
+    id_col = Attribute("""""")
+    header = Attribute("""""")
+    languages = Attribute("""""")
+    concepts = Attribute("""""")
+
+    def __len__(self):
+        """"""
+
+    def __iter__(self):
+        """"""
+
+
+class IWriter(Interface):
+    """"""
+    def get(self, **kw):
+        """"""
+
+    def write(self, path, **kw):
+        """"""
+
+
 class ISoundClassModel(Interface):
     """
     Interface for sound-class models.

--- a/lingpy3/io/__init__.py
+++ b/lingpy3/io/__init__.py
@@ -2,7 +2,7 @@
 """
 LingPy3 input and output functionality
 
-Input means creating lingpy3 objects from user input such as text of files. Generally,
+Input means creating lingpy3 objects from user input such as text or files. Generally,
 this is realized through readers (adapters in ZCA lingo), adapting the type of user input
 to the desired lingpy3 interface.
 

--- a/lingpy3/io/__init__.py
+++ b/lingpy3/io/__init__.py
@@ -1,0 +1,61 @@
+# coding: utf8
+"""
+LingPy3 input and output functionality
+
+Input means creating lingpy3 objects from user input such as text of files. Generally,
+this is realized through readers (adapters in ZCA lingo), adapting the type of user input
+to the desired lingpy3 interface.
+
+Output means converting lingpy3 objects to text or files. This is implemented via writers,
+again adapters, this time from a lingpy3 object interface to IWriter.
+
+Since both, readers and writers are adapters, it is easy
+- to add more (by providing additional implementations and adding these to the registry)
+- to customize existing readers or writers, by registering customizations under the same
+  same name.
+"""
+from __future__ import unicode_literals, print_function, division
+
+from clldutils.path import path_component
+
+from lingpy3.log import file_written
+from lingpy3.registry import get_adapter, register_adapter, get_interface, get_adapters
+from lingpy3 import interfaces
+from lingpy3.io.reader import base as readbase
+from lingpy3.io.reader import wordlist as readwl
+from lingpy3.io.writer import base as writebase
+from lingpy3.io.writer import wordlist as writewl
+
+for adapter in [
+    writebase.Txt,
+    writewl.Csv,
+    writewl.PapsNex,
+    readwl.Csv,
+]:
+    register_adapter(adapter)
+
+
+def read(obj, interface, name, **kw):
+    adapter = get_adapter(readbase.wrapped(obj), get_interface(interface), name=name)
+    return adapter(**kw)
+
+
+def get(obj, name, **kw):
+    adapter = get_adapter(obj, interfaces.IWriter, name=name)
+    return adapter.get(**kw)
+
+
+def write(obj, name, outdir=None, stem=None, **kw):
+    adapter = get_adapter(obj, interfaces.IWriter, name=name)
+    outfile = outdir.joinpath(path_component('{0}.{1}'.format(stem, name)))
+    adapter.write(outfile, **kw)
+    file_written(outfile)
+    return outfile
+
+
+def iter_writers(obj):
+    return get_adapters(obj, interfaces.IWriter)
+
+
+def iter_readers(obj, interface):
+    return get_adapters(readbase.wrapped(obj), get_interface(interface))

--- a/lingpy3/io/reader/__init__.py
+++ b/lingpy3/io/reader/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/io/reader/base.py
+++ b/lingpy3/io/reader/base.py
@@ -1,0 +1,62 @@
+# coding: utf8
+"""
+
+"""
+from __future__ import unicode_literals, print_function, division
+
+from zope.interface import implementer
+from six import text_type
+from clldutils.path import Path
+
+from lingpy3 import interfaces
+
+
+# To make the ZCA adapter mechanisms work for reader classes, we must make text and path
+# types available for adaption. Since these types are defined outside of lingpy3, we just
+# provide wrappers, implementing the corresponding interfaces.
+class Wrapper(object):
+    def __init__(self, obj):
+        self.obj = obj
+
+
+@implementer(interfaces.IText)
+class TextWrapper(Wrapper):
+    pass
+
+
+@implementer(interfaces.IPath)
+class PathWrapper(Wrapper):
+    pass
+
+
+def wrapped(obj):
+    if isinstance(obj, text_type):
+        return TextWrapper(obj)
+    if isinstance(obj, Path):
+        return PathWrapper(obj)
+    return obj
+
+
+def unwrapped(obj):
+    if isinstance(obj, Wrapper):
+        return obj.obj
+    return obj
+
+
+class BaseReader(object):
+    """
+    Virtual base class for Reader objects.
+
+    Derived classes must declare the interface of the object they return when called
+    using the @implementer decorator.
+    """
+    name = ''
+
+    def __init__(self, obj):
+        self.obj = unwrapped(obj)
+
+    def __call__(self, **kw):
+        """
+        When called, a Reader must return an initialized object providing the interface.
+        """
+        raise NotImplemented()  # pragma: no cover

--- a/lingpy3/io/reader/wordlist.py
+++ b/lingpy3/io/reader/wordlist.py
@@ -1,0 +1,20 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+
+from zope.interface import implementer
+from zope.component import adapts
+from clldutils.dsv import reader
+
+from lingpy3.interfaces import IWordlist, IPath
+from lingpy3.basic.wordlist import Wordlist
+from lingpy3.io.reader.base import BaseReader
+
+
+@implementer(IWordlist)
+class Csv(BaseReader):
+    name = 'csv'
+    adapts(IPath)
+
+    def __call__(self, **kw):
+        rows = list(reader(self.obj, delimiter=kw.pop('delimiter', None)))
+        return Wordlist(rows[0], rows[1:], **kw)

--- a/lingpy3/io/writer/__init__.py
+++ b/lingpy3/io/writer/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/io/writer/base.py
+++ b/lingpy3/io/writer/base.py
@@ -1,0 +1,28 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+
+from zope.interface import implementer
+from zope.component import adapts
+
+from lingpy3.interfaces import IWriter, IWordlist, ISoundClassModel
+
+
+@implementer(IWriter)
+class BaseWriter(object):
+    def __init__(self, obj):
+        self.obj = obj
+
+    def get(self, **kw):  # pragma: no cover
+        raise NotImplemented()
+
+    def write(self, path, **kw):
+        with path.open('w', encoding='utf8') as fp:
+            fp.write(self.get(**kw))
+
+
+class Txt(BaseWriter):
+    name = 'txt'
+    adapts(IWordlist, ISoundClassModel)
+
+    def content(self, **kw):
+        return '%s' % self.obj

--- a/lingpy3/io/writer/base.py
+++ b/lingpy3/io/writer/base.py
@@ -24,5 +24,5 @@ class Txt(BaseWriter):
     name = 'txt'
     adapts(IWordlist, ISoundClassModel)
 
-    def content(self, **kw):
+    def get(self, **kw):
         return '%s' % self.obj

--- a/lingpy3/io/writer/wordlist.py
+++ b/lingpy3/io/writer/wordlist.py
@@ -1,0 +1,62 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+
+from zope.component import adapts
+from clldutils.dsv import UnicodeWriter
+
+from lingpy3.io.writer.base import BaseWriter
+from lingpy3.interfaces import IWordlist
+
+
+class Csv(BaseWriter):
+    name = 'csv'
+    adapts(IWordlist)
+
+    def get(self, **kw):
+        with UnicodeWriter(f=None, delimiter=kw.get('delimiter')) as writer:
+            writer.writerow(self.obj.header)
+            for row in self.obj:
+                writer.writerow(row)
+        return writer.read().decode('utf8')
+
+
+class PapsNex(BaseWriter):
+    name = 'paps.nex'
+    adapts(IWordlist)
+
+    def get(self, **kw):
+        missing = kw.pop('missing', 0)
+        paps = sorted(self.obj.iter_paps(
+            ref=kw.pop('ref', 'cogid'),
+            concept=kw.pop('concept', None),
+            missing=missing))
+
+        template = """\
+#NEXUS
+
+BEGIN DATA;
+DIMENSIONS ntax={0} NCHAR={1};
+FORMAT DATATYPE=STANDARD GAP=- MISSING={2} interleave=yes;
+MATRIX
+
+{3}
+;
+
+END;
+[PAPS-REFERENCE]
+{4}
+"""
+
+        max_taxon = max([len(taxon) for taxon in self.obj.languages])
+        matrix = []
+        for i, taxon in enumerate(self.obj.languages):
+            matrix.append(('{0:%s} {1}' % max_taxon).format(
+                taxon, ''.join('%s' % itm[i] for _, itm in paps)))
+
+        return template.format(
+            len(self.obj.languages),
+            len(paps),
+            missing,
+            '\n'.join(matrix),
+            '\n'.join('[{0} :: {1}]'.format(i, ref) for i, (ref, _) in enumerate(paps))
+        )

--- a/lingpy3/log.py
+++ b/lingpy3/log.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 import warnings
 
 from six import text_type
+from clldutils.path import as_unicode
 
 from lingpy3.config import Config
 
@@ -108,7 +109,7 @@ def error(msg, **kw):
 
 def file_written(fname, logger=None):
     logger = logger or get_logger()
-    logger.info("Data has been written to file <{0}>.".format(fname))
+    logger.info("File created at <{0}>.".format(as_unicode(fname)))
 
 
 def deprecated(old, new):

--- a/lingpy3/tests/algorithm/__init__.py
+++ b/lingpy3/tests/algorithm/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/tests/algorithm/test_cython.py
+++ b/lingpy3/tests/algorithm/test_cython.py
@@ -1,0 +1,232 @@
+# coding: utf8
+from __future__ import print_function, division
+from unittest import TestCase
+
+from lingpy3.algorithm.cython import _talign
+from lingpy3.algorithm.cython import _calign
+from lingpy3.algorithm.cython import _malign
+
+
+class Tests(TestCase):
+    def setUp(self):
+        self.seqA = list('abab')
+        self.seqB = list('bababa')
+        self.seqA2 = list('ab1ab')
+        self.seqB2 = list('bab1aba')
+        self.m = len(self.seqA)
+        self.n = len(self.seqB)
+        self.scorer = {
+                ("a", "b"): -1,
+                ("b", "a"): -1,
+                ("a", "a"): 1,
+                ("b", "b"): 1,
+                ("1", "1"): 1,
+                ("a", "1"): -1,
+                ("b", "1"): -1,
+                ("1", "a"): -1,
+                ("1", "b"): -1
+                }
+        self.gop = -1
+        self.gap = -1
+        self.scale = 0.5
+        self.gopA = [-1, -1, -1, -1]
+        self.gopB = [-2, -1, -1, -1, -1, -0.5]
+        self.gopA2 = [-1, -1, -1, -1, -1]
+        self.gopB2 = [-2, -1, -1, -1, -1, -1, -0.5]
+        self.weightA = [1.5, 1, 1, 1]
+        self.weightB = [1.5, 1, 1, 1, 1, 0.5]
+        self.weightA2 = [1.5, 1, 1, 1, 1]
+        self.weightB2 = [1.5, 1, 1, 1, 1, 1, 0.5]
+        self.proA = 'abbc'
+        self.proB = 'abbbbc'
+        self.proA2 = 'ab1bc'
+        self.proB2 = 'abb1bbc'
+
+        self.factor = 0.3
+
+        self.profileA = [['a', 'b'], ['a', 'b']]
+        self.profileB = [
+            ['b', 'a', 'b', 'a', 'b', 'a'],
+            ['b', 'a', 'b', 'a', 'X', 'X']]
+        self.profileA2 = [['a', '1', 'b'], ['a', '1', 'b']]
+        self.profileB2 = [
+            ['b', 'a', 'b', '1', 'a', 'b', 'a'],
+            ['b', 'a', 'b', '1', 'a', 'X', 'X']]
+
+    def test__talign(self):
+        almA, almB, sim = _talign.globalign(
+            self.seqA, self.seqB, self.m,
+            self.n, self.gop, self.scale, self.scorer)
+        assert round(sim, 2) == 2.5
+        almA, almB, sim = _talign.semi_globalign(
+            self.seqA, self.seqB, self.m,
+            self.n, self.gop, self.scale, self.scorer)
+        assert round(sim, 2) == 4.0
+        almA, almB, sim = _talign.localign(
+            self.seqA, self.seqB, self.m,
+            self.n, self.gop, self.scale, self.scorer)
+        assert round(sim, 2) == 4.0
+        almA, almB, sim = _talign.dialign(
+            self.seqA, self.seqB, self.m,
+            self.n, self.scale, self.scorer)
+        assert round(sim, 2) == 4.0
+        
+        for mode in ['global', 'overlap', 'local', 'dialign']:
+            almA, almB, sim = _talign.align_pair(
+                self.seqA, self.seqB,
+                self.gop, self.scale, self.scorer, mode, distance=1)
+            assert sim < 1
+            
+            alignments = _talign.align_pairwise(
+                [self.seqA, self.seqB],
+                self.gop, self.scale, self.scorer, mode)
+            assert alignments[0][-1] < 1
+            alignments = _talign.align_pairs(
+                [[self.seqA, self.seqB]],
+                self.gop, self.scale, self.scorer, mode, 0)
+            assert alignments[0][-1] > 1
+            alignments = _talign.align_pairs(
+                [[self.seqA, self.seqB]],
+                self.gop, self.scale, self.scorer, mode, 1)
+            assert alignments[0][-1] < 1
+        for mode in ['global', 'overlap', 'dialign']:
+            profiles = _talign.align_profile(
+                self.profileA, self.profileB,
+                self.gop, self.scale, self.scorer, mode, 0.5)
+            assert profiles[-1] == 0.0
+
+        self.assertEqual(
+            _talign.score_profile(['a', 'a'], ['a', 'a'], self.scorer, self.gop, 0), 1)
+
+        self.assertAlmostEqual(
+            _talign.swap_score_profile(['a', '+'], ['X', 'X'], self.scorer, 0, 0), 0.0)
+
+    def test__malign(self):
+        almA, almB, sim = _malign.nw_align(self.seqA, self.seqB, self.scorer, self.gap)
+        assert sim == 2
+        dist = _malign.edit_dist(self.seqA, self.seqB, False)
+        assert dist == 2
+        dist = _malign.edit_dist(self.seqA, self.seqB, True)
+        assert dist < 1 and dist > 0
+        almA, almB, sim = _malign.sw_align(self.seqA, self.seqB, self.scorer, self.gap)
+        assert sim == 4
+        alms = _malign.we_align(self.seqA, self.seqB, self.scorer, self.gap)
+        assert alms[0][-1] == 4
+        alms = _malign.structalign('abab', 'cdcd')
+        assert len(alms[0]) == 1
+        assert alms[1] == 2
+        sim = _malign.restricted_edit_dist(
+            list('vava'), list('vivi'), 'cvcv', 'cvcv', False)
+        assert sim == 2
+        sim = _malign.restricted_edit_dist(
+            list('vava'), list('vivi'), 'cvcv', 'cvcv', True)
+        assert round(sim, 2) == 0.5
+
+    def test__calign(self):
+        almA, almB, sim = _calign.globalign(
+            self.seqA, self.seqB, self.gopA,
+            self.gopB, self.proA, self.proB, self.m,
+            self.n, self.scale, self.factor, self.scorer)
+        assert round(sim, 2) == 3.1
+        almA, almB, sim = _calign.semi_globalign(
+            self.seqA, self.seqB, self.gopA,
+            self.gopB, self.proA, self.proB, self.m,
+            self.n, self.scale, self.factor, self.scorer)
+        assert round(sim, 2) == 4.9
+        almA, almB, sim = _calign.localign(
+            self.seqA, self.seqB, self.gopA,
+            self.gopB, self.proA, self.proB, self.m,
+            self.n, self.scale, self.factor, self.scorer)
+        assert round(sim, 2) == 4.9
+        almA, almB, sim = _calign.dialign(
+            self.seqA, self.seqB,
+            self.proA, self.proB, self.m,
+            self.n, self.scale, self.factor, self.scorer)
+        assert round(sim, 2) == 4.9
+
+        almA, almB, sim = _calign.secondary_globalign(
+            self.seqA2, self.seqB2, self.gopA2,
+            self.gopB2, self.proA2, self.proB2, len(self.seqA2),
+            len(self.seqB2), self.scale, self.factor, self.scorer, '1')
+        assert round(sim, 2) == 4.4
+        almA, almB, sim = _calign.secondary_semi_globalign(
+            self.seqA2, self.seqB2, self.gopA2,
+            self.gopB2, self.proA2, self.proB2, len(self.seqA2),
+            len(self.seqB2), self.scale, self.factor, self.scorer, '1')
+        assert round(sim, 2) == 5.2
+        almA, almB, sim = _calign.secondary_localign(
+            self.seqA2, self.seqB2, self.gopA2,
+            self.gopB2, self.proA2, self.proB2, len(self.seqA2),
+            len(self.seqB2), self.scale, self.factor, self.scorer, '1')
+        assert round(sim, 2) == 6.2
+        almA, almB, sim = _calign.secondary_dialign(
+            self.seqA2, self.seqB2,
+            self.proA2, self.proB2, len(self.seqA2),
+            len(self.seqB2), self.scale, self.factor, self.scorer, '1')
+        assert round(sim, 2) == 6.2
+
+        for mode in ['global', 'overlap', 'local', 'dialign']:
+            almA, almB, sim = _calign.align_pair(
+                self.seqA, self.seqB,
+                self.weightA, self.weightB, self.proA, self.proB, self.gop,
+                self.scale, self.factor, self.scorer, mode,
+                '1', 1)
+            assert sim < 1
+            
+            alignments = _calign.align_pairwise(
+                [self.seqA, self.seqB],
+                [self.weightA, self.weightB],
+                [self.proA, self.proB], self.gop, self.scale, self.factor,
+                self.scorer, '1', mode)
+            assert alignments[0][-1] < 1
+            alignments = _calign.align_pairwise(
+                [self.seqA2, self.seqB2],
+                [self.weightA2, self.weightB2],
+                [self.proA2, self.proB2], self.gop, self.scale, self.factor,
+                self.scorer, '1', mode)
+            assert alignments[0][-1] < 1 
+            alignments = _calign.align_pairs(
+                [[self.seqA, self.seqB]],
+                [[self.weightA, self.weightB]],
+                [[self.proA, self.proB]], self.gop, self.scale, self.factor,
+                self.scorer, mode, '1', 1)
+            assert alignments[0][-1] < 1
+            alignments = _calign.align_pairs(
+                [[self.seqA2, self.seqB2]],
+                [[self.weightA2, self.weightB2]],
+                [[self.proA2, self.proB2]], self.gop, self.scale, self.factor,
+                self.scorer, mode, '1', 0)
+            assert alignments[0][-1] > 1
+
+        for mode in ['global', 'overlap', 'dialign']:
+            profiles = _calign.align_profile(
+                self.profileA, self.profileB,
+                self.weightA, self.weightB, self.proA, self.proB, self.gop,
+                self.scale, self.factor, self.scorer, '1', mode, 0.5)
+            assert profiles[-1] == 0.0
+            profiles = _calign.align_profile(
+                self.profileA2, self.profileB2,
+                self.weightA2, self.weightB2, self.proA2, self.proB2, self.gop,
+                self.scale, self.factor, self.scorer, '1', mode, 0.5)
+            assert len(profiles) == 3
+
+        assert _calign.score_profile(['a', 'a'], ['a', 'a'], self.scorer, 0) == 1
+        assert _calign.swap_score_profile(['a', '+'], ['X', 'X'], self.scorer, 0) < 0
+
+    def test_corrdist(self):
+        seqs1 = [[self.seqA, self.seqB]]
+        seqs2 = [[self.seqA2, self.seqB2]]
+        gops1 = [[self.weightA, self.weightB]]
+        gops2 = [[self.weightA2, self.weightB2]]
+        pros1 = [[self.proA, self.proB]]
+        pros2 = [[self.proA2, self.proB2]]
+
+        for mode in ['global', 'local', 'dialign', 'overlap']:
+            corr1 = _calign.corrdist(
+                0.5, seqs1, gops1, pros1, self.gop, self.scale,
+                self.factor, self.scorer, mode, '1')
+            corr2 = _calign.corrdist(
+                0.5, seqs2, gops2, pros2, self.gop, self.scale,
+                self.factor, self.scorer, mode, '1')
+            assert corr1[0]['b', 'b'] == 2
+            assert corr2[0]['a', 'a'] == 2 

--- a/lingpy3/tests/io/__init__.py
+++ b/lingpy3/tests/io/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division

--- a/lingpy3/tests/io/test_init.py
+++ b/lingpy3/tests/io/test_init.py
@@ -1,0 +1,16 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+
+from clldutils.testing import WithTempDir
+
+
+class Tests(WithTempDir):
+    def test_create_representation(self):
+        from lingpy3.basic.wordlist import Wordlist
+        from lingpy3.io import write, read
+
+        wl = Wordlist(['id', 'concept', 'doculect'], [['ä', 'ö', 'ü']])
+        out = write(wl, 'csv', self.tmp_path(), 'test', delimiter='\t')
+        self.assertTrue(out.exists())
+        wl2 = read(out, Wordlist, 'csv', delimiter='\t')
+        self.assertEqual(wl[1], wl2[1])

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ requires = [
     'clldutils>=1.5.1',
     'tqdm',
     'zope.interface>=4.3',
+    'zope.component>=4.3',
 ]
 
 


### PR DESCRIPTION
While I think using the [ZCA](http://muthukadan.net/docs/zca.html) was already a good idea for things like sound class models, adapters truly come in handy to separate (and wire together) IO-related code.

Apart from making code layout simpler and more structured, having all IO code registered at one place allows additional functionality like listing all available writers for a given object:
```python
>>> from lingpy3.io import read, iter_writers, write
>>> from clldutils.path import Path
>>> from lingpy3.basic.wordlist import Wordlist
>>> wl = read(Path('test.tsv'), Wordlist, 'csv', delimiter='\t', id_='ID')
>>> for name, adapter in iter_writers(wl):
...     print(name, adapter)
... 
(u'csv', <lingpy3.io.writer.wordlist.Csv object at 0x7f1465db78d0>)
(u'paps.nex', <lingpy3.io.writer.wordlist.PapsNex object at 0x7f1465db7890>)
>>> write(wl, 'paps.nex', outdir=Path('.'), stem='wl', ref='cognates')
2016-11-23 12:21:43,251 [INFO] File created at <wl.paps.nex>.
PosixPath('wl.paps.nex')
```