### PR TITLE
Support for serialization

### DIFF
--- a/lingpy3/basic/wordlist.py
+++ b/lingpy3/basic/wordlist.py
@@ -66,6 +66,23 @@ class Wordlist(object):
         if len(self._id2index) != len(self._rows):
             raise ValueError('duplicate row IDs in wordlist')
 
+    def __eq__(self, other):
+        return self.header == other.header and self._rows == other._rows
+
+    def __json__(self):
+        return {
+            'header': self.header,
+            'rows': self._rows,
+            'kwargs': {
+                'id_': self.id_col,
+                'concept': self.concept_col,
+                'language': self.language_col}
+        }
+
+    @classmethod
+    def __from_json__(cls, val):
+        return cls(val['header'], val['rows'], **val['kwargs'])
+
     def _row_index(self, row):
         """
         :param row: int or text_type, specifying 1-based row index or row ID.

--- a/lingpy3/jsonlib.py
+++ b/lingpy3/jsonlib.py
@@ -1,0 +1,31 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+from hashlib import md5
+import json
+
+from six import text_type
+from clldutils.path import Path, path_component
+from clldutils.jsonlib import load as cu_load
+
+
+def dump(obj, outdir=None, stem=None):
+    if hasattr(obj, '__json__'):
+        obj = obj.__json__()
+    val = json.dumps(obj, indent=4, sort_keys=True)
+    if isinstance(val, text_type):
+        val = val.encode('utf8')  # pragma: no cover
+    outfile = path_from_checksum(stem or md5(val).hexdigest(), outdir=outdir)
+    with outfile.open('wb') as fp:
+        fp.write(val)
+    return outfile
+
+
+def path_from_checksum(checksum, outdir=None):
+    return (outdir or Path('.')).joinpath(path_component('{0}.json'.format(checksum)))
+
+
+def load(path, cls=None):
+    val = cu_load(path)
+    if cls:
+        val = cls.__from_json__(val)
+    return val

--- a/lingpy3/ops/__init__.py
+++ b/lingpy3/ops/__init__.py
@@ -1,16 +1,31 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function, division
 
+from clldutils.path import as_unicode
+
 # Note: We have to import all modules which register adapters to make sure these adapter
 # are already registered before a user can override these by re-registering.
 from lingpy3 import interfaces
 from lingpy3.registry import get_adapter, get_adapters, format_adapters_doc
 from lingpy3.ops import wordlist
+from lingpy3.jsonlib import load, dump, path_from_checksum
+from lingpy3.cache import CACHE_DIR
 
 
 def run(name, obj, **kw):
     adapter = get_adapter(obj, interfaces.IOperation, name=name)
     return adapter(**kw)
+
+
+def run_and_dump(name, obj, __checksum__=None, **kw):
+    adapter = get_adapter(obj, interfaces.IOperation, name=name)
+    if __checksum__:
+        cached = path_from_checksum(__checksum__, outdir=CACHE_DIR)
+        if cached.exists():
+            return load(cached, cls=adapter.returns), __checksum__
+    res = adapter(**kw)
+    out = dump(res, outdir=CACHE_DIR)
+    return res, as_unicode(out.stem)
 
 
 def iter_ops(obj):

--- a/lingpy3/ops/base.py
+++ b/lingpy3/ops/base.py
@@ -11,6 +11,8 @@ class BaseOperation(object):
     """
     Virtual base class for Operation objects.
     """
+    returns = None
+
     def __init__(self, obj):
         self.obj = obj
 
@@ -21,9 +23,13 @@ class BaseOperation(object):
         raise NotImplemented()  # pragma: no cover
 
 
-def operation(adapts, name=None):
+def operation(adapts, returns=None, name=None):
     """
     Decorator for simplified implementation and registration of IOperations.
+
+    :param returns: Operations that return an object of a non-builtin type must specify \
+    the class of the return value.
+    :param name: A name under which to register the operation.
     """
     def wrap(f):
         from lingpy3.registry import register_adapter_from_factory
@@ -33,6 +39,7 @@ def operation(adapts, name=None):
             BaseOperation,
             clsname='Operation_{0}_{1}'.format(adapts.__name__, name or f.__name__),
             __call__=lambda self, **kw: f(self.obj, **kw),
+            returns=returns,
             name=name or f.__name__)
         return f
     return wrap

--- a/lingpy3/sequence/soundclassmodel.py
+++ b/lingpy3/sequence/soundclassmodel.py
@@ -39,6 +39,17 @@ class DiacriticsVowelsTones(NamedObject):
         self.vowels = vowels
         self.tones = tones
 
+    def __eq__(self, other):
+        return all(getattr(self, k) == getattr(other, k)
+                   for k in 'diacritics vowels tones'.split())
+
+    def __json__(self):
+        return {k: getattr(self, k) for k in 'name diacritics vowels tones'.split()}
+
+    @classmethod
+    def __from_json__(cls, val):
+        return cls(*[val[k] for k in 'name diacritics vowels tones'.split()])
+
     @classmethod
     def from_path(cls, path):
         cache = Cache()

--- a/lingpy3/tests/ops/test_init.py
+++ b/lingpy3/tests/ops/test_init.py
@@ -1,14 +1,26 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function, division
-from unittest import TestCase
+
+from clldutils.testing import WithTempDir
+from mock import patch
 
 from lingpy3.tests.fixtures import make_wordlist
 
 
-class Tests(TestCase):
+class Tests(WithTempDir):
     def test_misc(self):
         from lingpy3.ops import run, list_ops_doc
 
         wl = make_wordlist()
         self.assertIn('distances', set(spec[0] for spec in list_ops_doc(wl)))
         self.assertIsInstance(run('distances', wl), list)
+
+    def test_run_and_dump(self):
+        from lingpy3.ops import run_and_dump
+        from lingpy3.jsonlib import path_from_checksum
+
+        with patch('lingpy3.ops.CACHE_DIR', self.tmp_path()):
+            wl = make_wordlist()
+            res, checksum = run_and_dump('distances', wl)
+            run_and_dump('distances', wl, __checksum__=checksum)
+            self.assertTrue(path_from_checksum(checksum, outdir=self.tmp_path()).exists())

--- a/lingpy3/tests/sequence/test_soundclassmodel.py
+++ b/lingpy3/tests/sequence/test_soundclassmodel.py
@@ -1,11 +1,12 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function, division
-from unittest import TestCase
 from collections import defaultdict
 
 from mock import patch
+from clldutils.testing import WithTempDir
 
 from lingpy3.util import data_path
+from lingpy3 import jsonlib
 
 
 MATRIX_DISS = [
@@ -418,7 +419,7 @@ CONVERTER_ASJP = {
 }
 
 
-class Tests(TestCase):
+class Tests(WithTempDir):
     def test_SoundClassModel(self):
         from lingpy3.sequence.soundclassmodel import SoundClassModel
 
@@ -453,3 +454,10 @@ class Tests(TestCase):
 
         with patch('lingpy3.sequence.soundclassmodel.Cache', dict):
             DiacriticsVowelsTones.from_name('dvt')
+
+        dvt = DiacriticsVowelsTones.from_name('dvt')
+        self.assertEqual(
+            dvt,
+            jsonlib.load(
+                jsonlib.dump(dvt, outdir=self.tmp_path()),
+                cls=DiacriticsVowelsTones))

--- a/lingpy3/tests/test_jsonlib.py
+++ b/lingpy3/tests/test_jsonlib.py
@@ -1,0 +1,27 @@
+# coding: utf8
+from __future__ import unicode_literals, print_function, division
+from collections import OrderedDict
+
+from clldutils.testing import WithTempDir
+
+from lingpy3.basic.wordlist import Wordlist
+from lingpy3.tests.fixtures import make_wordlist
+
+
+class Tests(WithTempDir):
+    def test_dump_load_dict(self):
+        from lingpy3.jsonlib import load, dump
+
+        d = {'a': 2, 'z': 1}
+        out = dump(d, outdir=self.tmp_path())
+        self.assertEqual(d, load(out))
+        d2 = OrderedDict([('z', 1), ('a', 2)])
+        out2 = dump(d2, outdir=self.tmp_path())
+        self.assertEqual(out.name, out2.name)
+
+    def test_dump_load_custom(self):
+        from lingpy3.jsonlib import load, dump
+
+        wl = make_wordlist()
+        out = dump(wl, outdir=self.tmp_path())
+        self.assertEqual(wl, load(out, Wordlist))


### PR DESCRIPTION
We support custom serialization of objects as JSON via a lightweight
protocol. This serialization can be used with a variant of the `ops.run`
function to dump/load results of operations.